### PR TITLE
Support a-frame scenes

### DIFF
--- a/src/panel/inspected-win/50-inspected-win-main.js
+++ b/src/panel/inspected-win/50-inspected-win-main.js
@@ -52,8 +52,7 @@ InspectedWin3js.postMessageToPanel     = function(type, data){
 
 
 InspectedWin3js.getObjectByUuid = function(uuid){
-        // FIXME use scene as a global
-        return scene.getObjectByProperty('uuid', uuid)
+        return InspectedWin3js.getInspectedScene().getObjectByProperty('uuid', uuid)
 }
 
 InspectedWin3js.getInspectedScene = function(){

--- a/src/panel/inspected-win/50-inspected-win-main.js
+++ b/src/panel/inspected-win/50-inspected-win-main.js
@@ -57,8 +57,13 @@ InspectedWin3js.getObjectByUuid = function(uuid){
 }
 
 InspectedWin3js.getInspectedScene = function(){
-        if( window.scene instanceof THREE.Scene === false ) return null
-        return window.scene;
+        var scene = window.scene
+        if (!scene) {
+          var aFrameScene = document.querySelector('a-scene')
+          if (aFrameScene) scene = aFrameScene.object3D
+        }
+        if( scene instanceof THREE.Scene === false ) return null
+        return scene;
 }
 
 /**


### PR DESCRIPTION
Hi!  a-frame is an increasingly popular Threejs based framework, and it would be great if the threejs inspector 'just worked' for anything using it.  This will check for a-scene objects if there is no global 'scene' var.
