### PR TITLE
Stop internal log messages from showing up in prod version.

### DIFF
--- a/src/panel/inspected-win/00-inspected-win-prefix.js
+++ b/src/panel/inspected-win/00-inspected-win-prefix.js
@@ -39,13 +39,13 @@
 	// export namespace globally
 	window.InspectedWin3js = InspectedWin3js
 	
-	InspectedWin3js.REVISION	= '1.9.11'
+	InspectedWin3js.REVISION	= '1.9.12'
 	
 	//////////////////////////////////////////////////////////////////////////////////
 	//		Comments
 	//////////////////////////////////////////////////////////////////////////////////
 	// determine which environment we run in thanks to the version number
-	// - simple principle: even patch number are dev version, odd patch number are production versions
+	// - simple principle: odd patch number are dev version, even patch number are production versions
 	InspectedWin3js.ENVIRONMENT	= parseInt(InspectedWin3js.REVISION.split('.').pop()) % 2 ? 'dev' : 'prod'
 	
 	// remove InspectedWin3js.log in production


### PR DESCRIPTION
The version that is in the chrome store ( https://chrome.google.com/webstore/detail/threejs-inspector/dnhjfclbfhcbcdfpjaeacomhbdfjbebi?utm_source=chrome-app-launcher-info-dialog )  is dumping log messages all over the console.

This is due to InspectedWin3js.REVISION being at an odd number. This fixes it, and also the comment that explained it the wrong way around.

PS: thanks for making / improving this awesome tool! Makes three.js work a lot easier.